### PR TITLE
fix: add hooks and commit if git repo exists and prepend package.json scripts

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,8 +16,8 @@ const execSyncOptions = {
 /**
  * Runs command.
  *
- * @param {String} command
- * @return {String}
+ * @param {string} command
+ * @return {string}
  */
 const exec = command => execSync(command, execSyncOptions);
 
@@ -31,7 +31,7 @@ const log = (...args) => console.log('INFO:', ...args);
 /**
  * Writes to file.
  *
- * @param {String} file
+ * @param {string} file
  * @param {*} data
  */
 const write = (file, data) =>
@@ -40,6 +40,9 @@ const write = (file, data) =>
     (typeof data === 'string' ? data : JSON.stringify(data, null, 2)) + '\n'
   );
 
+/**
+ * Display exit code.
+ */
 process.on('exit', code => {
   log(`Exiting with code: ${code}`);
 });
@@ -65,9 +68,9 @@ try {
  */
 const packageJsonPath = resolve(cwd, 'package.json');
 if (existsSync(packageJsonPath)) {
-  log('Found `package.json`');
+  log('`package.json` found');
 } else {
-  log('Unable to find `package.json`, initializing new package...');
+  log('`package.json` not found, initializing `package.json`...');
   exec('npm init --yes');
 }
 

--- a/index.js
+++ b/index.js
@@ -86,13 +86,33 @@ const devDependencies = [
  */
 const packageJson = require(packageJsonPath);
 packageJson.scripts = packageJson.scripts || {};
-packageJson.scripts.release = 'standard-version --no-verify';
-packageJson.scripts.postinstall = 'husky install';
+const { postinstall, release } = packageJson.scripts;
+
+const huskyInstall = 'husky install';
+packageJson.scripts.postinstall = postinstall
+  ? `${huskyInstall} && ${postinstall}`
+  : huskyInstall;
+
+const standardVersion = 'standard-version --no-verify';
+packageJson.scripts.release = release
+  ? `${standardVersion} && ${release}`
+  : standardVersion;
+
 if (!packageJson.private) {
   devDependencies.push('pinst');
-  packageJson.scripts.prepublishOnly = 'pinst --disable';
-  packageJson.scripts.postpublish = 'pinst --enable';
+  const { postpublish, prepublishOnly } = packageJson.scripts;
+
+  const pinstEnable = 'pinst --enable';
+  packageJson.scripts.postpublish = postpublish
+    ? `${pinstEnable} && ${postpublish}`
+    : pinstEnable;
+
+  const pinstDisable = 'pinst --disable';
+  packageJson.scripts.prepublishOnly = prepublishOnly
+    ? `${pinstDisable} && ${prepublishOnly}`
+    : pinstDisable;
 }
+
 write(packageJsonPath, packageJson);
 
 /**
@@ -120,7 +140,7 @@ readdirSync(filesPath).forEach(filename => {
  */
 if (isGit) {
   log('Adding hooks...');
-  exec(`npx husky install`);
+  exec(`npx ${huskyInstall}`);
   exec(`npx husky add .husky/commit-msg 'npx commitlint --edit $1'`);
   exec('git add .husky/');
 }


### PR DESCRIPTION
## What is the motivation for this pull request?

fix: add hooks and commit if git repo exists and prepend `package.json` scripts instead of overriding them

## What is the current behavior?

- Husky hooks are always added (throws an error if git repository is not found)
- `package.json` scripts `postinstall`, `postpublish`, `prepublishOnly`, and `release` are overridden
- Changes are always committed (throws an error if git repository is not found)

## What is the new behavior?

- Add husky hooks if git repository is found
- Prepend `package.json` scripts instead of overriding them
- Commit changes if git repository is found
