### PR TITLE
feat: replace `standard-version` with `release-please.yml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,13 @@ npm install --global conventional-release-setup
 conventional-release-setup
 ```
 
-## Explanation
+If you want to release with [standard-version](https://www.npmjs.com/package/standard-version), then use v1:
+
+```sh
+npx conventional-release-setup@1
+```
+
+## What It Does
 
 The script:
 
@@ -40,12 +46,12 @@ The script:
   - [@commitlint/cli](https://www.npmjs.com/package/@commitlint/cli) - lints commit messages
   - [@commitlint/config-conventional](https://www.npmjs.com/package/@commitlint/config-conventional) - config with [conventional commits](https://conventionalcommits.org/) rules
   - [husky](https://www.npmjs.com/package/husky) - sets up git hooks
-  - [standard-version](https://www.npmjs.com/package/standard-version) - generates changelog, bumps version, and creates git commit and tag
-- copies the config:
+- copies the configs:
+  - [.github/workflows/release-please.yml](https://github.com/google-github-actions/release-please-action) - generates changelog, bumps version, and creates git commit, tag, and release
   - [.commitlintrc.json](https://github.com/remarkablemark/conventional-release-setup/blob/master/files/.commitlintrc.json)
 - adds husky hook `commit-msg`
 
-If the package is not `private`, the script also:
+If the package is not `private`, then the script:
 
 - updates `package.json` scripts:
   - prepends `pinst --enable` to `postpublish`
@@ -55,35 +61,7 @@ If the package is not `private`, the script also:
 
 ## Release
 
-If `-alpha` is appended to your `package.json` version:
-
-```json
-{
-  "version": "1.0.0-alpha"
-}
-```
-
-You can run a release like so:
-
-```sh
-npm run release # npx standard-version --no-verify
-```
-
-Otherwise, you can [release as a target type imperatively](https://github.com/conventional-changelog/standard-version#release-as-a-target-type-imperatively-npm-version-like):
-
-```sh
-npx standard-version --release-as 1.0.0
-```
-
-Or if you want to use the current version as your [first release](https://github.com/conventional-changelog/standard-version#first-release):
-
-```sh
-npx standard-version --first-release
-```
-
-## Release
-
-Release and publish are automated by [Release Please](https://github.com/googleapis/release-please).
+Release is automated with [Release Please](https://github.com/google-github-actions/release-please-action).
 
 ## License
 

--- a/files/.github/workflows/release-please.yml
+++ b/files/.github/workflows/release-please.yml
@@ -1,0 +1,15 @@
+name: release-please
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Release Please
+        uses: google-github-actions/release-please-action@v3
+        with:
+          release-type: node

--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -17,6 +17,25 @@ exports[`CLI copies .commitlintrc.json 1`] = `
 }
 `;
 
+exports[`CLI copies .github/workflows/release-please.yml 1`] = `
+"name: release-please
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Release Please
+        uses: google-github-actions/release-please-action@v3
+        with:
+          release-type: node
+"
+`;
+
 exports[`CLI updates package.json 1`] = `
 {
   "author": "",
@@ -26,7 +45,6 @@ exports[`CLI updates package.json 1`] = `
     "@commitlint/config-conventional": "^17.7.0",
     "husky": "^8.0.3",
     "pinst": "^3.0.0",
-    "standard-version": "^9.5.0",
   },
   "keywords": [],
   "license": "ISC",
@@ -36,7 +54,6 @@ exports[`CLI updates package.json 1`] = `
     "postinstall": "husky install",
     "postpublish": "pinst --enable",
     "prepublishOnly": "pinst --disable",
-    "release": "standard-version --no-verify",
     "test": "echo "Error: no test specified" && exit 1",
   },
   "version": "1.0.0",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -35,6 +35,12 @@ describe('CLI', () => {
     expect(JSON.parse(readFileSync('.commitlintrc.json'))).toMatchSnapshot();
   });
 
+  it('copies .github/workflows/release-please.yml', () => {
+    expect(
+      readFileSync('.github/workflows/release-please.yml'),
+    ).toMatchSnapshot();
+  });
+
   it('adds .husky/.commit-msg', () => {
     expect(readFileSync('.husky/commit-msg')).toMatchSnapshot();
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,6 @@ const devDependencies = [
   '@commitlint/cli',
   '@commitlint/config-conventional',
   'husky',
-  'standard-version',
 ];
 
 /**
@@ -69,17 +68,12 @@ const devDependencies = [
  */
 const packageJson = require(packageJsonPath);
 packageJson.scripts = packageJson.scripts || {};
-const { postinstall, release } = packageJson.scripts;
+const { postinstall } = packageJson.scripts;
 
 const huskyInstall = 'husky install';
 packageJson.scripts.postinstall = postinstall
   ? `${huskyInstall} && ${postinstall}`
   : huskyInstall;
-
-const standardVersion = 'standard-version --no-verify';
-packageJson.scripts.release = release
-  ? `${standardVersion} && ${release}`
-  : standardVersion;
 
 if (!packageJson.private) {
   devDependencies.push('pinst');
@@ -109,14 +103,9 @@ isGit && exec('git add package.json');
  * Copy files.
  */
 log('Copying files...');
-const filesPath = path.resolve(__dirname, '../files');
-fs.readdirSync(filesPath).forEach((filename: string) => {
-  const source = path.resolve(filesPath, filename);
-  const destination = path.resolve(cwd, filename);
-  log(`Copying \`${filename}\``);
-  fs.copyFileSync(source, destination);
-  isGit && exec(`git add ${filename}`);
-});
+fs.cpSync(path.resolve(__dirname, '../files'), cwd, { recursive: true });
+isGit &&
+  exec(`git add .commitlintrc.json .github/workflows/release-please.yml`);
 
 /**
  * Add hooks.


### PR DESCRIPTION
## What is the motivation for this pull request?

BREAKING CHANGE: replace `standard-version` with `release-please.yml`

## What is the current behavior?

Release is done with [standard-version](https://github.com/conventional-changelog/standard-version)

## What is the new behavior?

Release is done with [Release Please](https://github.com/google-github-actions/release-please-action)

## Checklist:

- [x] Tests
- [x] Documentation